### PR TITLE
Adding options to enable + control profile data generation

### DIFF
--- a/modeling.py
+++ b/modeling.py
@@ -27,6 +27,7 @@ import numpy as np
 import six
 import tensorflow as tf
 tf.compat.v1.disable_resource_variables()
+tf.compat.v1.disable_eager_execution()
 
 
 class BertConfig(object):

--- a/optimization.py
+++ b/optimization.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import re
 import tensorflow as tf
 tf.compat.v1.disable_resource_variables()
+tf.compat.v1.disable_eager_execution()
 
 try:
   import horovod.tensorflow as hvd


### PR DESCRIPTION
This commit adds the `--enable_timeline`, and `--num_timeline_steps` options to the following scripts
 * `run_pretraining.py`
 * `run_squad.py`
 * `run_classifier.py`

Specifying the `--enable_timeline` option enables the generation of profiling data ( `timeline-*.json` files).

The frequency with which the `timeline-*.json` files are generated can be controlled via the `--num_timeline_steps=N` option. The default value of N is 1, which means a timeline-K.json file will be generated for each step, when K is the step number.
Specifying
 * N=2 will results in the generation of timeline-*.json for every other step
 * N=3 will results in the generation of timeline-*.json for every third step
 * and so on

The `timline-*.json` files are written out to the directory specified by the --output_dir option

-----------------------------------------

@c0redumb @xdgarrido @micmelesse @ekuznetsov139 please review and merge